### PR TITLE
Refactor rest api

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,80 +1,63 @@
 import os
+from typing import List, Dict, Any
 
+import bson
 from dotenv import load_dotenv
 from flask import Flask, render_template, request
 from pymongo import MongoClient
+from pymongo.collection import Collection
+from pymongo.database import Database
 
-# connect to your database environment variable for your connect
+# Access your MongoDB Atlas cluster and get a `Cursor` to its `books` collection.
 load_dotenv()
-mongo_uri = os.environ.get('MONGO_URI')
-connect = MongoClient(mongo_uri)
+connection_string: str = os.environ.get("CONNECTION_STRING")
+mongo_client: MongoClient = MongoClient(connection_string)
+bookshelf_database: Database = mongo_client.get_database("bookshelf")
+books_collection: Collection = bookshelf_database.get_collection("books")
 
-# add in your database and collection from Atlas
-database = connect["bookshelf"]
-collection = database["books"]
-
-# instantiating new object with "name"
-app = Flask(__name__)
+app: Flask = Flask(__name__)
 
 
-# our initial form page
-@app.route('/')  # root is "/"
+# The default endpoints "/"
+@app.route("/")
 def index():
     return render_template("index.html")
 
 
-# CREATE
-@app.route('/new-book', methods=['POST'])
-def add_book():
-    # POST new book this is how you'll enter it in Postman
-    if request.method == 'POST':
-        # request.json returns a JSON object. So you'll see it pretty in Postman
-        book = request.json['book']
-        pages = request.json['pages']
+@app.route("/books", methods=["GET", "POST"])
+def books():
+    if request.method == "POST":
+        # CREATE
+        title: str = request.json["title"]
+        pages: str = request.json["pages"]
+        books_collection.insert_one({"title": title, "pages": pages})
+        return f"CREATE: Your book {title} ({pages} pages) has been added to your bookshelf.\n"
 
-        # insert new book into books collection in MongoDB
-        database['books'].insert_one({"book": book, "pages": pages})
+    elif request.method == "GET":
+        # READ
+        book_list: List[Dict[Any, Any]] = list(books_collection.find())
+        book_list = list(
+            map(lambda book: {"id": str(book["_id"]), "title": book["title"], "pages": book["pages"]}, book_list))
+        return book_list
 
-        return "update: Your book has been added to your bookshelf."
-
-
-# READ
-@app.route('/view-books', methods=['GET'])
-def view_book():
-    if request.method == 'GET':
-        # view all books in your mongodb database
-        bookshelf = list(database['books'].find())
-        titles = []
-
-        # make it pretty
-        for books in bookshelf:
-            book = books['book']
-            pages = books['pages']
-            shelf = {'book': book, 'pages': pages}
-            # books will go to the top of the list
-            titles.insert(0, shelf)
-        print(titles)
-
-        return titles
+    else:
+        return "Method not allowed!\n"
 
 
 # UPDATE
-@app.route('/exchange-book/<string:name>/<int:pages>', methods=['PUT'])  # to update in postman use PUT
-def exchange_book(name, pages):
-    if request.method == 'PUT':
-        new_book = request.json['book']
-        new_pages = request.json['pages']
+@app.route("/books/<string:book_id>", methods=["PUT"])
+def update_book(book_id: str):
+    title: str = request.json["title"]
+    pages: str = request.json["pages"]
+    books_collection.update_one({"_id": bson.ObjectId(book_id)},
+                                {"$set": {"book": title, "pages": pages}})
 
-        # this updates your selected book
-        database['books'].update_one({"book": name, "pages": pages}, {"$set": {"book": new_book, "pages": new_pages}})
-
-        return "update: Your book has been exchanged."
+    return f"Update: Your book has been updated to: {title} ({pages} pages)\n"
 
 
-# DELETE WORKS
-@app.route('/remove-book/<string:name>/<int:pages>', methods=['DELETE'])
-def remove_book(name, pages):
-    if request.method == 'DELETE':
-        database['books'].delete_one({"book": name, "pages": pages})
+# DELETE
+@app.route("/books/<string:book_id>", methods=["DELETE"])
+def remove_book(book_id: str):
+    books_collection.delete_one({"_id": bson.ObjectId(book_id)})
 
-        return "update: Your book has been removed from your bookshelf."
+    return f"DELETE: Your book (id = {book_id}) has been removed from your bookshelf.\n"


### PR DESCRIPTION
This PR refactors the REST API so that it looks like a typical RESTful API:
- All `book`-related endpoints are now sorted into `/books` with the same endpoint accepting different methods
- PUT and DELETE use the ID as part of the URL instead of title and pages.
- DELETE also uses the ID

There are many great resources out there for RESTful API design, just the first one I found: https://stackoverflow.blog/2020/03/02/best-practices-for-rest-api-design/

Smaller changes that happened as part of this:
- Type annotations, see https://docs.python.org/3/library/typing.html
- I renamed several fields (the books vs. bookshelf vs. book thing I mentioned in Slack), should be clearer now

N.B.: This PR is based on the previous one (https://github.com/anaiyaraisin/azuredemo/pull/1). To make it easier to see the diff, I've created a temporary PR from one into the other: https://github.com/DominicFrei/azuredemo/pull/1